### PR TITLE
fix https sources

### DIFF
--- a/lib/terraspace_bundler/mod.rb
+++ b/lib/terraspace_bundler/mod.rb
@@ -23,8 +23,11 @@ module TerraspaceBundler
       url_words[-1]
     end
 
+    # https://github.com/tongueroo/pet - 2nd to last word
+    # git@github.com:tongueroo/pet - 2nd to last word without chars before :
     def org
-      url_words[-2] # second to last word
+      s = url_words[-2] # second to last word
+      s.split(':').last # in case of git@github.com:tongueroo/pet form
     end
 
     def full_repo

--- a/lib/terraspace_bundler/mod/props_builder.rb
+++ b/lib/terraspace_bundler/mod/props_builder.rb
@@ -35,7 +35,20 @@ class TerraspaceBundler::Mod
       if registry?
         registry.github_url
       else
-        "#{TB.config.base_clone_url}#{source}" # Note: make sure to not use @source, is org may no be added
+        git_source_url
+      end
+    end
+
+    def git_source_url
+      if @source.include?('http') || @source.include?(':')
+        # Examples:
+        #   mod "pet", source: "https://github.com/tongueroo/pet"
+        #   mod "pet", source: "git@github.com:tongueroo/pet"
+        @source
+      else
+        # Examples:
+        #   mod "pet", source: "tongueroo/pet"
+        "#{TB.config.base_clone_url}#{source}" # Note: make sure to not use @source, org may not be added
       end
     end
 


### PR DESCRIPTION
Related #6 

This fixes `git@github.com:example` sources.

```ruby
mod "app-core-git", source: "git@github.com:example-com/app-core.git"
```

This does not fix the private registry yet though.
