### PR TITLE
ssh notation support

### DIFF
--- a/lib/terraspace_bundler.rb
+++ b/lib/terraspace_bundler.rb
@@ -1,10 +1,12 @@
 $:.unshift(File.expand_path("../", __FILE__))
+require "active_support"
 require "active_support/core_ext/class"
 require "active_support/core_ext/hash"
 require "active_support/core_ext/string"
 require "active_support/ordered_options"
 require "dsl_evaluator"
 require "fileutils"
+require "json"
 require "memoist"
 require "rainbow/ext/string"
 require "singleton"

--- a/lib/terraspace_bundler/dsl/syntax.rb
+++ b/lib/terraspace_bundler/dsl/syntax.rb
@@ -1,7 +1,7 @@
 class TerraspaceBundler::Dsl
   module Syntax
-    def org(url)
-      config.org = url
+    def org(value)
+      config.org = value
     end
     alias_method :user, :org
 

--- a/lib/terraspace_bundler/mod/concerns/notation_concern.rb
+++ b/lib/terraspace_bundler/mod/concerns/notation_concern.rb
@@ -11,7 +11,8 @@ module TerraspaceBundler::Mod::Concerns
     end
 
     def remove_subfolder_notation(source)
-      parts = clean_notation(source).split('//')
+      clean = clean_notation(source)
+      parts = clean.split('//')
       if parts.size == 2 # has subfolder
         source.split('//')[0..-2].join('//') # remove only subfolder, keep rest of original source
       else
@@ -20,7 +21,8 @@ module TerraspaceBundler::Mod::Concerns
     end
 
     def subfolder(source)
-      parts = clean_notation(source).split('//')
+      clean = clean_notation(source)
+      parts = clean.split('//')
       if parts.size == 2 # has subfolder
         remove_ref_notation(parts.last)
       end
@@ -35,8 +37,23 @@ module TerraspaceBundler::Mod::Concerns
       end
     end
 
+
     def clean_notation(source)
-      source.sub(/.*::/,'').sub(%r{http[s?]://},'').sub(%r{git@(.*?):},'') # also remove git@ notation
+      clean = source
+        .sub(/.*::/,'')            # remove git::
+        .sub(%r{http[s?]://},'')   # remove https://
+        .sub(%r{git@(.*?):},'')    # remove git@word
+      remove_host(clean)
+    end
+
+    def remove_host(clean)
+      return clean unless clean.include?('ssh://')
+      if clean.count(':') == 1
+        uri = URI(clean)
+        uri.path
+      else
+        clean.split(':').last
+      end
     end
   end
 end

--- a/lib/terraspace_bundler/mod/concerns/path_concern.rb
+++ b/lib/terraspace_bundler/mod/concerns/path_concern.rb
@@ -18,11 +18,11 @@ module TerraspaceBundler::Mod::Concerns
     end
 
     def cache_path(name)
-      [cache_root, parent_stage_folder, name].compact.join('/')
+      [cache_root, @mod.type, name].compact.join('/')
     end
 
     def stage_path(name)
-      [stage_root, parent_stage_folder, name].compact.join('/')
+      [stage_root, @mod.type, name].compact.join('/')
     end
 
     # Fetcher: Downloader/Local copies to a slightly different folder.
@@ -41,21 +41,8 @@ module TerraspaceBundler::Mod::Concerns
       when 'http'
         path = type_path # https://www.googleapis.com/storage/v1/BUCKET_NAME/PATH/TO/module.zip
         remove_ext(path) # terraform-example-modules/modules/example-module
-      when -> (_) { @mod.source.include?('git::') }
-        @mod.name      # example-module
-      else # inferred git, registry
-        @mod.full_repo #  tongueroo/example-module
-      end
-    end
-
-    def parent_stage_folder
-      case @mod.type
-      when 'local'
-        'local'
-      when 'http'
-        'http'
-      else # gcs, s3, git, registry
-        @mod.vcs_provider
+      else # inferred git, registry, git::, ssh://, git::ssh://
+        @mod.repo_folder #  tongueroo/example-module
       end
     end
 

--- a/lib/terraspace_bundler/mod/fetcher/git.rb
+++ b/lib/terraspace_bundler/mod/fetcher/git.rb
@@ -4,11 +4,11 @@ class TerraspaceBundler::Mod::Fetcher
 
     def run
       setup_tmp
-      org_path = cache_path(@mod.org)
-      FileUtils.mkdir_p(org_path)
+      org_folder = cache_path(@mod.org_folder)
+      FileUtils.mkdir_p(org_folder)
 
-      Dir.chdir(org_path) do
-        logger.debug "Current root dir: #{org_path}"
+      Dir.chdir(org_folder) do
+        logger.debug "Current root dir: #{org_folder}"
         clone unless File.exist?(@mod.repo)
 
         Dir.chdir(@mod.repo) do
@@ -45,12 +45,13 @@ class TerraspaceBundler::Mod::Fetcher
       if found
         found.split(':').last.strip
       else
-        'master'
+        ENV['TS_GIT_DEFAULT_BRANCH'] || 'master'
       end
     end
 
     def switch_version(version)
       stage_path = stage_path(rel_dest_dir)
+      logger.debug "stage_path #{stage_path}"
       Dir.chdir(stage_path) do
         git "checkout #{version}"
         @sha = git("rev-parse HEAD").strip

--- a/lib/terraspace_bundler/mod/org_repo.rb
+++ b/lib/terraspace_bundler/mod/org_repo.rb
@@ -1,0 +1,65 @@
+class TerraspaceBundler::Mod
+  class OrgRepo
+    def initialize(url)
+      @url = url.sub('ssh://','') # important to copy so dont change the string reference
+    end
+
+    def repo
+      org_repo_words[-1]
+    end
+
+    def org
+      s = org_folder.split('/').last
+      s ? s.split('/').last : 'none'
+    end
+
+    def org_folder
+      org_repo_words[-2] # second to last word
+    end
+
+    def repo_folder
+      org_repo_words.join('/')
+    end
+
+    def org_repo_words
+      if @url.include?(':') && !@url.match(%r{http[s?]://}) # user@host:repo git@github.com:org/repo
+        folder, repo = handle_string_with_colon
+      else # IE: https://github.com/org/repo, org/repo, etc
+        parts = @url.split('/')
+        folder = parts[0..-2].join('/')
+        repo = parts.last
+      end
+
+      org_path = clean_folder(folder)
+      repo = strip_dot_git(repo)
+      [org_path, repo]
+    end
+
+    def clean_folder(folder)
+      folder.sub(%r{.*@},'')           # remove user@
+            .sub(%r{http[s?]://},'')   # remove https://
+    end
+
+    # user@host:repo git@github.com:org/repo
+    def handle_string_with_colon
+      host, path = @url.split(':')
+      if path.size == 2
+        folder, repo = path.split(':')
+      else
+        folder = join(host, File.dirname(path))
+        repo = File.basename(path)
+      end
+      [folder, repo]
+    end
+
+    def join(*path)
+      path.compact!
+      path[1] = path[1].sub('/','') if path[1].starts_with?('/')
+      path.reject(&:blank?).join('/')
+    end
+
+    def strip_dot_git(s)
+      s.sub(/\.git$/,'')
+    end
+  end
+end

--- a/lib/terraspace_bundler/mod/props/typer.rb
+++ b/lib/terraspace_bundler/mod/props/typer.rb
@@ -12,7 +12,9 @@ class TerraspaceBundler::Mod::Props
 
     # IE: git or registry
     def type
-      if source.include?('::')
+      if source.include?('ssh://')
+        "git"
+      elsif source.include?('::')
         source.split('::').first # IE: git:: s3:: gcs::
       elsif local?
         "local"

--- a/readme/qa/Terrafile
+++ b/readme/qa/Terrafile
@@ -1,0 +1,39 @@
+# Here's an example Terrafile that can be used to qa the different types of sources.
+# Based on: https://terraspace.cloud/docs/terrafile/sources/
+# Note: Actually need to make sure that have access to the sources, IE: s3, gcs, github, etc
+# This is still useful as an example to help with QA.
+
+# Use modules from the Terraform registry
+mod "sqs", source: "terraform-aws-modules/sqs/aws"
+mod "s3", source: "git@github.com:boltops-tools/terraform-aws-s3"
+mod "s3test", source: "boltops-tools/terraform-aws-s3"
+
+mod "test1", source: "git::https://github.com/boltops-tools/terraform-aws-s3"
+mod "test2", source: "git::ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
+mod "test3", source: "git::ssh://ec2-user@localhost:environment/repo"
+mod "test4", source: "git::ssh://localhost:environment/repo"
+mod "test5", source: "ssh://ec2-user@localhost/home/ec2-user/environment/repo"
+mod "test6", source: "ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
+mod "test7", source: "ssh://ec2-user@localhost:/home/ec2-user/environment/repo//subfolder"
+mod "test8", source: "ssh://ec2-user@localhost:environment/repo"
+mod "test9", source: "ssh://ec2-user@localhost:repo"
+
+mod "pet1", source: "tongueroo/pet"
+mod "pet2", source: "https://github.com/tongueroo/pet"
+mod "example1", source: "git@bitbucket.org:tongueroo/example-module.git"
+mod "example2", source: "git@gitlab.com:tongueroo/example-module"
+
+org "tongueroo"
+mod "pet3", source: "pet" # inferred org
+
+mod "sg", source: "terraform-aws-modules/security-group/aws" # terraform registry public example
+mod "pet4", source: "app.terraform.io/boltops/pet/random" # , clone_with: "https"
+
+mod "demo1", source: "s3::https://s3-us-west-2.amazonaws.com/demo-terraform-test/modules/example-module.tgz"
+mod "demo2", source: "s3::https://s3-us-west-2.amazonaws.com/demo-terraform-test/modules/example-module.zip"
+mod "demo3", source: "gcs::https://www.googleapis.com/storage/v1/terraform-example-modules/modules/example-module.zip//subfolder"
+mod "demo4", source: "gcs::https://www.googleapis.com/storage/v1/terraform-example-modules/modules/example-module.tgz//subfolder"
+
+mod "local1", source: "/home/ec2-user/environment/downloads/example-module"
+mod "local2", source: "./example-module"
+mod "local3", source: "~/environment/infra-terrafile/example-module"

--- a/spec/terraform_bundler/mod/concerns/notation_concern_spec.rb
+++ b/spec/terraform_bundler/mod/concerns/notation_concern_spec.rb
@@ -1,0 +1,35 @@
+class NotationTest
+  include TB::Mod::Concerns::NotationConcern
+end
+
+describe NotationTest do
+  let(:notation) { described_class.new }
+
+  context "clean_notation" do
+    it "cleans" do
+      source = "git::ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "/home/ec2-user/environment/repo"
+
+      source = "ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "/home/ec2-user/environment/repo"
+
+      source = "ssh://ec2-user@localhost:/home/ec2-user/environment/repo//subfolder"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "/home/ec2-user/environment/repo//subfolder"
+
+      source = "git::ssh://ec2-user@localhost:environment/repo"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "environment/repo"
+
+      source = "ssh://ec2-user@localhost:~/environment/repo"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "~/environment/repo"
+
+      source = "git::ssh://localhost:environment/repo"
+      cleaned = notation.clean_notation(source)
+      expect(cleaned).to eq "environment/repo"
+    end
+  end
+end

--- a/spec/terraform_bundler/mod/org_repo_spec.rb
+++ b/spec/terraform_bundler/mod/org_repo_spec.rb
@@ -1,0 +1,45 @@
+describe TB::Mod::OrgRepo do
+  let(:org_repo) { described_class.new(url) }
+
+  context "ssh://ec2-user@localhost/repo" do
+    let(:url) { "ssh://ec2-user@localhost/repo" }
+    it "org repo" do
+      # puts "org_repo.org #{org_repo.org}"
+      # puts "org_repo.repo #{org_repo.repo}"
+      expect(org_repo.org_folder).to eq "localhost"
+      expect(org_repo.repo_folder).to eq "localhost/repo"
+    end
+  end
+
+  context "ssh://ec2-user@localhost/long/path/to/repo" do
+    let(:url) { "ssh://ec2-user@localhost/long/path/to/repo" }
+    it "org repo" do
+      expect(org_repo.org_folder).to eq "localhost/long/path/to"
+      expect(org_repo.repo_folder).to eq "localhost/long/path/to/repo"
+    end
+  end
+
+  context "ec2-user@localhost:long/path/to/repo" do
+    let(:url) { "ec2-user@localhost:long/path/to/repo" }
+    it "org repo" do
+      expect(org_repo.org_folder).to eq "localhost/long/path/to"
+      expect(org_repo.repo_folder).to eq "localhost/long/path/to/repo"
+    end
+  end
+
+  context "git@github.com:org/repo" do
+    let(:url) { "git@github.com:org/repo" }
+    it "org repo" do
+      expect(org_repo.org_folder).to eq "github.com/org"
+      expect(org_repo.repo_folder).to eq "github.com/org/repo"
+    end
+  end
+
+  context "https://github.com/org/repo" do
+    let(:url) { "https://github.com/org/repo" }
+    it "org repo" do
+      expect(org_repo.org_folder).to eq "github.com/org"
+      expect(org_repo.repo_folder).to eq "github.com/org/repo"
+    end
+  end
+end

--- a/spec/terraform_bundler/mod/props_spec.rb
+++ b/spec/terraform_bundler/mod/props_spec.rb
@@ -31,4 +31,134 @@ describe TB::Mod::Props do
       expect(url).to eq "git@gitlab.com:tongueroo/example-module.git"
     end
   end
+
+  # context terrafile = evaulated Terrafile DSL results in these type of options being passed to Props#build
+  context "terrafile" do
+    let(:params) do
+      {
+        :args=>["repo"],
+        :options=>{:source=>source},
+        :source=>"git::ssh://ec2-user@localhost:/home/ec2-user/environment/repo",
+        :name=>"repo",
+        :type=>"git",
+        :url=>"ssh:",
+        :subfolder=>"ec2-user@localhost:/home/ec2-user/environment/repo", :ref=>nil
+
+      }
+    end
+    context "git@github.com source" do
+      let(:source) { "git@github.com:boltops-tools/terraform-aws-s3" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"git@github.com:boltops-tools/terraform-aws-s3",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"git@github.com:boltops-tools/terraform-aws-s3",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+        expect(props.url).to eq "git@github.com:boltops-tools/terraform-aws-s3"
+        expect(props.type).to eq "git"
+        expect(props.source).to eq "git@github.com:boltops-tools/terraform-aws-s3"
+      end
+    end
+    context "https://github.com source" do
+      let(:source) { "https://github.com/boltops-tools/random_pet" }
+      it "properties" do
+        expect(props.url).to eq "https://github.com/boltops-tools/random_pet"
+        expect(props.type).to eq "git"
+        expect(props.source).to eq "https://github.com/boltops-tools/random_pet"
+      end
+    end
+    context "explicit org source" do
+      let(:source) { "boltopspro/terraform-aws-elasticache" }
+      it "properties" do
+        expect(props.url).to eq "https://github.com/boltopspro/terraform-aws-elasticache"
+        expect(props.type).to eq "git"
+        expect(props.source).to eq "boltopspro/terraform-aws-elasticache"
+      end
+    end
+    context "terraform registry source" do
+      let(:source) { "terraform-aws-modules/security-group/aws" }
+      it "properties" do
+        expect(props.url).to eq "https://github.com/terraform-aws-modules/terraform-aws-security-group"
+        expect(props.type).to eq "registry"
+        expect(props.source).to eq "terraform-aws-modules/security-group/aws"
+      end
+    end
+    context "ssh with explicit user source" do
+      let(:source) { "ssh://user@host:/path/to/repo" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"ssh://user@host:/path/to/repo",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"user@host:/path/to/repo",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+      end
+    end
+    context "ssh with implied user source" do
+      let(:source) { "ssh://host:/path/to/repo" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"ssh://host:/path/to/repo",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"host:/path/to/repo",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+      end
+    end
+
+    context "ssh 2-level folder source" do
+      let(:source) { "ssh://ec2-user@localhost:environment/repo" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"ssh://ec2-user@localhost:environment/repo",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"ec2-user@localhost:environment/repo",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+      end
+    end
+
+    context "ssh 1-level folder source" do
+      let(:source) { "ssh://ec2-user@localhost:repo" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"ssh://ec2-user@localhost:repo",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"ec2-user@localhost:repo",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+      end
+    end
+
+    context "ssh without colon supports only absolute path source" do
+      let(:source) { "ssh://ec2-user@localhost/home/ec2-user/repo" }
+      it "properties" do
+        result = props.build
+        expect(result).to eq(
+          {:source=>"ssh://ec2-user@localhost/home/ec2-user/repo",
+           :name=>"repo",
+           :type=>"git",
+           :url=>"ssh://ec2-user@localhost/home/ec2-user/repo",
+           :subfolder=>nil,
+           :ref=>nil}
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds support for ssh git clone notation. 

Tested several examples:

Terrafile

```ruby
mod "test1", source: "git::https://github.com/boltops-tools/terraform-aws-s3"
mod "test2", source: "git::ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
mod "test3", source: "git::ssh://ec2-user@localhost:environment/repo"
mod "test4", source: "git::ssh://localhost:environment/repo"
mod "test5", source: "ssh://ec2-user@localhost/home/ec2-user/environment/repo"
mod "test6", source: "ssh://ec2-user@localhost:/home/ec2-user/environment/repo"
mod "test7", source: "ssh://ec2-user@localhost:/home/ec2-user/environment/repo//subfolder"
mod "test8", source: "ssh://ec2-user@localhost:environment/repo"
mod "test9", source: "ssh://ec2-user@localhost:repo"
```

Also, re-tested the other sources examples on https://terraspace.cloud/docs/terrafile/sources/

Related: 

* Community Post: https://community.boltops.com/t/terrafile-ssh-support/810
* Docs PR: https://github.com/boltops-tools/terraspace-docs/pull/27
* Docs Link: https://terraspace.cloud/docs/terrafile/sources/ssh/